### PR TITLE
Update simple-tester-python - add missing variable which is additionally returned compared to older version of libqmi/python API

### DIFF
--- a/examples/simple-tester-python/simple-tester-python
+++ b/examples/simple-tester-python/simple-tester-python
@@ -64,25 +64,25 @@ def get_ids_ready(qmiclient,result,qmidev):
         return
 
     try:
-        imei = output.get_imei()
+        found, imei = output.get_imei()
         print("imei:                  %s" % imei)
     except:
         pass
 
     try:
-        imei_software_version = output.get_imei_software_version()
+        found, imei_software_version = output.get_imei_software_version()
         print("imei software version: %s" % imei_software_version)
     except:
         pass
 
     try:
-        meid = output.get_meid()
+        found, meid = output.get_meid()
         print("meid:                  %s" % meid)
     except:
         pass
 
     try:
-        esn = output.get_esn()
+        found, esn = output.get_esn()
         print("esn:                   %s" % esn)
     except:
         pass
@@ -95,7 +95,7 @@ def get_capabilities_ready(qmiclient,result,qmidev):
         output = qmiclient.get_capabilities_finish(result)
         output.get_result()
 
-        maxtxrate, maxrxrate, dataservicecaps, simcaps, radioifaces = output.get_info()
+        found, maxtxrate, maxrxrate, dataservicecaps, simcaps, radioifaces = output.get_info()
         print("max tx channel rate:   %u" % maxtxrate)
         print("max rx channel rate:   %u" % maxrxrate)
         print("data service:          %s" % Qmi.DmsDataServiceCapability.get_string(dataservicecaps))

--- a/examples/simple-tester-python/simple-tester-python
+++ b/examples/simple-tester-python/simple-tester-python
@@ -65,25 +65,37 @@ def get_ids_ready(qmiclient,result,qmidev):
 
     try:
         found, imei = output.get_imei()
-        print("imei:                  %s" % imei)
+        if found:
+            print("imei:                  %s" % imei)
+        else: 
+            print("imei:                  -> error getting imei")
     except:
         pass
 
     try:
         found, imei_software_version = output.get_imei_software_version()
-        print("imei software version: %s" % imei_software_version)
+        if found:
+            print("imei software version: %s" % imei_software_version)
+        else:
+            print("imei software version: -> error getting imei_software_version")
     except:
         pass
 
     try:
         found, meid = output.get_meid()
-        print("meid:                  %s" % meid)
+        if found:
+            print("meid:                  %s" % meid)
+        else:
+            print("meid:                  -> error getting meid")
     except:
         pass
 
     try:
         found, esn = output.get_esn()
-        print("esn:                   %s" % esn)
+        if found:
+            print("esn:                   %s" % esn)
+        else:
+            print("esn:                   -> error getting esn")
     except:
         pass
 
@@ -96,16 +108,23 @@ def get_capabilities_ready(qmiclient,result,qmidev):
         output.get_result()
 
         found, maxtxrate, maxrxrate, dataservicecaps, simcaps, radioifaces = output.get_info()
-        print("max tx channel rate:   %u" % maxtxrate)
-        print("max rx channel rate:   %u" % maxrxrate)
-        print("data service:          %s" % Qmi.DmsDataServiceCapability.get_string(dataservicecaps))
-        print("sim:                   %s" % Qmi.DmsSimCapability.get_string(simcaps))
-        networks = ""
-        for radioiface in radioifaces:
-            if networks != "":
-                networks += ", "
-            networks += Qmi.DmsRadioInterface.get_string(radioiface)
-        print("networks:              %s" % networks)
+        if found:
+            print("max tx channel rate:   %u" % maxtxrate)
+            print("max rx channel rate:   %u" % maxrxrate)
+            print("data service:          %s" % Qmi.DmsDataServiceCapability.get_string(dataservicecaps))
+            print("sim:                   %s" % Qmi.DmsSimCapability.get_string(simcaps))
+            networks = ""
+            for radioiface in radioifaces:
+                if networks != "":
+                    networks += ", "
+                networks += Qmi.DmsRadioInterface.get_string(radioiface)
+            print("networks:              %s" % networks)
+        else:
+            print("max tx channel rate:   -> error getting capabilities")
+            print("max rx channel rate:   -> error getting capabilities")
+            print("data service:          -> error getting capabilities")
+            print("sim:                   -> error getting capabilities")
+            print("networks:              -> error getting capabilities")
 
     except GLib.GError as error:
         sys.stderr.write("Couldn't query device capabilities: %s\n" % error.message)


### PR DESCRIPTION
Some return structures seem to got a new variable in front: if result available or not.
Add missing variable, so python example can be used with up-to-date libqmi version